### PR TITLE
Task 25 - Support for Relative URLs in csm library

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,3 +33,5 @@ Start by importing the `csm` in your code.
 ```js
 import { config, stage, mint } from '@origyn-sa/csm';
 ```
+
+TODO: Provide usage instructions.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -56,7 +56,7 @@
 
 #### Defined in
 
-[types/config.ts:59](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/config.ts#L59)
+[types/config.ts:53](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/config.ts#L53)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[types/metadata.ts:16](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/metadata.ts#L16)
+[types/metadata.ts:16](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/metadata.ts#L16)
 
 ___
 
@@ -82,24 +82,23 @@ ___
 
 #### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `assetMappings` | `string` | mappings (string with comma delimited list of 'asset_type:file_name, ...') |
-| `collectionDisplayName` | `string` | display name of collection |
-| `collectionId` | `string` | collection id |
-| `creatorPrincipal` | `string` | principal id of creator |
-| `environment` | `string` | environment |
-| `folderPath` | `string` | folder path |
-| `namespace` | `string` | namespace for NFT resources |
-| `nftCanisterId` | `string` | id of canister |
-| `nftOwnerId` | `string` | owner of NFTs (if empty, defaults to NFT canister id) |
-| `nftQuantities` | `string` | quantity |
-| `soulbound` | `string` | soulbound (if empty, default to 'false') |
-| `tokenPrefix` | `string` | token prefix |
+| Name | Type |
+| :------ | :------ |
+| `assetMappings` | `string` |
+| `collectionDisplayName` | `string` |
+| `collectionId` | `string` |
+| `creatorPrincipal` | `string` |
+| `folderPath` | `string` |
+| `namespace` | `string` |
+| `nftCanisterId` | `string` |
+| `nftOwnerId` | `string` |
+| `nftQuantities` | `string` |
+| `soulbound` | `string` |
+| `tokenPrefix` | `string` |
 
 #### Defined in
 
-[types/config.ts:3](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/config.ts#L3)
+[types/config.ts:3](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/config.ts#L3)
 
 ___
 
@@ -118,7 +117,7 @@ ___
 
 #### Defined in
 
-[types/config.ts:73](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/config.ts#L73)
+[types/config.ts:67](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/config.ts#L67)
 
 ___
 
@@ -136,7 +135,6 @@ ___
 | `collectionLibraries` | [`LibraryFile`](modules.md#libraryfile)[] |
 | `fileMap` | [`FileInfoMap`](modules.md#fileinfomap) |
 | `nftDefinitionCount` | `number` |
-| `nftFolderNames` | `string`[] |
 | `nftQuantities` | `number`[] |
 | `nftsFolder` | `string` |
 | `stageFolder` | `string` |
@@ -145,7 +143,7 @@ ___
 
 #### Defined in
 
-[types/config.ts:33](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/config.ts#L33)
+[types/config.ts:28](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/config.ts#L28)
 
 ___
 
@@ -164,7 +162,7 @@ ___
 
 #### Defined in
 
-[types/config.ts:66](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/config.ts#L66)
+[types/config.ts:60](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/config.ts#L60)
 
 ___
 
@@ -183,7 +181,7 @@ ___
 
 #### Defined in
 
-[types/config.ts:48](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/config.ts#L48)
+[types/config.ts:42](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/config.ts#L42)
 
 ___
 
@@ -197,7 +195,7 @@ ___
 
 #### Defined in
 
-[types/config.ts:55](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/config.ts#L55)
+[types/config.ts:49](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/config.ts#L49)
 
 ___
 
@@ -214,7 +212,7 @@ ___
 
 #### Defined in
 
-[types/metadata.ts:3](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/metadata.ts#L3)
+[types/metadata.ts:3](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/metadata.ts#L3)
 
 ___
 
@@ -238,7 +236,7 @@ ___
 
 #### Defined in
 
-[types/logger.ts:1](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/logger.ts#L1)
+[types/logger.ts:1](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/logger.ts#L1)
 
 ___
 
@@ -256,7 +254,7 @@ ___
 
 #### Defined in
 
-[types/metadata.ts:38](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/metadata.ts#L38)
+[types/metadata.ts:38](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/metadata.ts#L38)
 
 ___
 
@@ -272,7 +270,7 @@ ___
 
 #### Defined in
 
-[types/metadata.ts:34](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/metadata.ts#L34)
+[types/metadata.ts:34](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/metadata.ts#L34)
 
 ___
 
@@ -290,7 +288,7 @@ ___
 
 #### Defined in
 
-[types/metadata.ts:28](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/metadata.ts#L28)
+[types/metadata.ts:28](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/metadata.ts#L28)
 
 ___
 
@@ -306,26 +304,17 @@ ___
 
 #### Defined in
 
-[types/stage.ts:6](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/stage.ts#L6)
+[types/stage.ts:7](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/stage.ts#L7)
 
 ___
 
 ### MintArgs
 
-Ƭ **MintArgs**: `Object`
-
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `batchSize?` | `string` |
-| `folderPath` | `string` |
-| `keyFilePath` | `string` |
-| `range?` | `string` |
+Ƭ **MintArgs**: [`StageArgs`](modules.md#stageargs) & { `batchSize?`: `string` ; `range?`: `string`  }
 
 #### Defined in
 
-[types/mint.ts:1](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/mint.ts#L1)
+[types/mint.ts:3](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/mint.ts#L3)
 
 ___
 
@@ -341,7 +330,7 @@ ___
 
 #### Defined in
 
-[types/metadata.ts:12](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/metadata.ts#L12)
+[types/metadata.ts:12](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/metadata.ts#L12)
 
 ___
 
@@ -357,7 +346,7 @@ ___
 
 #### Defined in
 
-[types/metadata.ts:20](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/metadata.ts#L20)
+[types/metadata.ts:20](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/metadata.ts#L20)
 
 ___
 
@@ -369,12 +358,13 @@ ___
 
 | Name | Type |
 | :------ | :------ |
+| `environment` | `string` |
 | `folderPath` | `string` |
 | `keyFilePath` | `string` |
 
 #### Defined in
 
-[types/stage.ts:1](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/stage.ts#L1)
+[types/stage.ts:1](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/stage.ts#L1)
 
 ___
 
@@ -390,7 +380,7 @@ ___
 
 #### Defined in
 
-[types/metadata.ts:8](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/metadata.ts#L8)
+[types/metadata.ts:8](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/metadata.ts#L8)
 
 ___
 
@@ -407,7 +397,7 @@ ___
 
 #### Defined in
 
-[types/metadata.ts:24](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/types/metadata.ts#L24)
+[types/metadata.ts:24](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/types/metadata.ts#L24)
 
 ## Functions
 
@@ -427,7 +417,7 @@ ___
 
 #### Defined in
 
-[methods/config.ts:14](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/methods/config.ts#L14)
+[methods/config.ts:14](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/methods/config.ts#L14)
 
 ___
 
@@ -447,7 +437,7 @@ ___
 
 #### Defined in
 
-methods/identity.ts:11
+[methods/identity.ts:19](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/methods/identity.ts#L19)
 
 ___
 
@@ -467,7 +457,7 @@ ___
 
 #### Defined in
 
-[methods/mint.ts:11](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/methods/mint.ts#L11)
+[methods/mint.ts:11](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/methods/mint.ts#L11)
 
 ___
 
@@ -487,7 +477,7 @@ ___
 
 #### Defined in
 
-[methods/arg-parser.ts:5](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/methods/arg-parser.ts#L5)
+[methods/arg-parser.ts:5](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/methods/arg-parser.ts#L5)
 
 ___
 
@@ -507,7 +497,7 @@ ___
 
 #### Defined in
 
-[methods/arg-parser.ts:64](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/methods/arg-parser.ts#L64)
+[methods/arg-parser.ts:64](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/methods/arg-parser.ts#L64)
 
 ___
 
@@ -527,7 +517,7 @@ ___
 
 #### Defined in
 
-[methods/arg-parser.ts:48](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/methods/arg-parser.ts#L48)
+[methods/arg-parser.ts:45](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/methods/arg-parser.ts#L45)
 
 ___
 
@@ -547,7 +537,7 @@ ___
 
 #### Defined in
 
-[methods/logger.ts:5](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/methods/logger.ts#L5)
+[methods/logger.ts:5](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/methods/logger.ts#L5)
 
 ___
 
@@ -567,7 +557,7 @@ ___
 
 #### Defined in
 
-[methods/stage.ts:13](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/methods/stage.ts#L13)
+[methods/stage.ts:13](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/methods/stage.ts#L13)
 
 ___
 
@@ -581,4 +571,4 @@ ___
 
 #### Defined in
 
-[methods/logger.ts:9](https://github.com/ORIGYN-SA/csm/blob/26965cb/src/methods/logger.ts#L9)
+[methods/logger.ts:9](https://github.com/ORIGYN-SA/csm/blob/3ce6252/src/methods/logger.ts#L9)

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -7,33 +7,33 @@ import { ConfigArgs } from '../types/config';
 
 const BUILD_FOLDER = '../../lib';
 const inputArgvShortNames =
-  '["/Users/jt/.nvm/versions/node/v16.15.1/bin/node","/Users/jt/test/origyn_nft_reference/projects/csm.js","config","-e","local","-c","bayc","-d","BAYC","-t","bayc-","-n","com.bayc.ape","-i","aaaaa-bbbbb-ccccc-ddddd-cai","-p","11111-22222-33333-44444-55555-66666-77777-88888-99999-11111-222","-s","true","-f","./projects/bayc-csm/__temp","-m","primary:ape*.png, preview:index.html, hidden:mystery-ape.gif","-o","aaaaa-bbbbb-ccccc-ddddd-eeeee-fffff-ggggg-iiiii-jjjjj-kkkkk-lll","-s","true","-q","5,5,5,5,1,1,1"]';
+  '["/Users/jt/.nvm/versions/node/v16.15.1/bin/node","/Users/jt/test/origyn_nft_reference/projects/csm.js","config","-c","bayc","-d","BAYC","-t","bayc-","-n","com.bayc.ape","-i","aaaaa-bbbbb-ccccc-ddddd-cai","-p","11111-22222-33333-44444-55555-66666-77777-88888-99999-11111-222","-s","true","-f","./projects/bayc-csm/__temp","-m","primary:ape*.png, preview:index.html, hidden:mystery-ape.gif","-o","aaaaa-bbbbb-ccccc-ddddd-eeeee-fffff-ggggg-iiiii-jjjjj-kkkkk-lll","-s","true","-q","5,5,5,5,1,1,1"]';
 const inputArgvShortNamesOmitOptional =
-  '["/Users/jt/.nvm/versions/node/v16.15.1/bin/node","/Users/jt/test/origyn_nft_reference/projects/csm.js","config","-e","local","-c","bayc","-d","BAYC","-t","bayc-","-n","com.bayc.ape","-i","rrkah-fqaaa-aaaaa-aaaaq-cai","-p","6i6da-t3dfv-vteyg-v5agl-tpgrm-63p4y-t5nmm-gi7nl-o72zu-jd3sc-7qe","-f","./projects/bayc-csm/__temp","-m","primary:ape*.png, preview:index.html, hidden:mystery-ape.gif"]';
+  '["/Users/jt/.nvm/versions/node/v16.15.1/bin/node","/Users/jt/test/origyn_nft_reference/projects/csm.js","config",,"-c","bayc","-d","BAYC","-t","bayc-","-n","com.bayc.ape","-i","rrkah-fqaaa-aaaaa-aaaaq-cai","-p","6i6da-t3dfv-vteyg-v5agl-tpgrm-63p4y-t5nmm-gi7nl-o72zu-jd3sc-7qe","-f","./projects/bayc-csm/__temp","-m","primary:ape*.png, preview:index.html, hidden:mystery-ape.gif"]';
 const inputArgvLongNames =
-  '["/Users/jt/.nvm/versions/node/v16.15.1/bin/node","/Users/jt/test/origyn_nft_reference/projects/csm.js","config","--environment","local","--collectionId","simple","--collectionDisplayName","Simple","--tokenPrefix","simple_","--nftCanisterId","rrkah-fqaaa-aaaaa-aaaaq-cai","--creatorPrincipal","6i6da-t3dfv-vteyg-v5agl-tpgrm-63p4y-t5nmm-gi7nl-o72zu-jd3sc-7qe","--namespace","ogy.simple","--folderPath","./projects/simple-video/assets","--assetMappings","primary:mike.png, experience:Origynator_Card_Mike_Schwartz_Small.mp4, preview:index.html","--soulbound","false","--nftQuantities","3"]';
+  '["/Users/jt/.nvm/versions/node/v16.15.1/bin/node","/Users/jt/test/origyn_nft_reference/projects/csm.js","config","--collectionId","simple","--collectionDisplayName","Simple","--tokenPrefix","simple_","--nftCanisterId","rrkah-fqaaa-aaaaa-aaaaq-cai","--creatorPrincipal","6i6da-t3dfv-vteyg-v5agl-tpgrm-63p4y-t5nmm-gi7nl-o72zu-jd3sc-7qe","--namespace","ogy.simple","--folderPath","./projects/simple-video/assets","--assetMappings","primary:mike.png, experience:Origynator_Card_Mike_Schwartz_Small.mp4, preview:index.html","--soulbound","false","--nftQuantities","3"]';
 
 const inputConfigArgs =
-  '{"environment":"local","collectionId":"bayc","collectionDisplayName":"BAYC","tokenPrefix":"bayc-","nftCanisterId":"rrkah-fqaaa-aaaaa-aaaaq-cai","creatorPrincipal":"6i6da-t3dfv-vteyg-v5agl-tpgrm-63p4y-t5nmm-gi7nl-o72zu-jd3sc-7qe","namespace":"com.bayc.ape","folderPath":"/Users/jt/test/origyn_nft_reference/projects/bayc-csm/__temp","assetMappings":"primary:ape*.png, preview:index.html, hidden:mystery-ape.gif","nftOwnerId":"6i6da-t3dfv-vteyg-v5agl-tpgrm-63p4y-t5nmm-gi7nl-o72zu-jd3sc-7qe","soulbound":"false","nftQuantities":""}';
+  '{"collectionId":"bayc","collectionDisplayName":"BAYC","tokenPrefix":"bayc-","nftCanisterId":"rrkah-fqaaa-aaaaa-aaaaq-cai","creatorPrincipal":"6i6da-t3dfv-vteyg-v5agl-tpgrm-63p4y-t5nmm-gi7nl-o72zu-jd3sc-7qe","namespace":"com.bayc.ape","folderPath":"/Users/jt/test/origyn_nft_reference/projects/bayc-csm/__temp","assetMappings":"primary:ape*.png, preview:index.html, hidden:mystery-ape.gif","nftOwnerId":"6i6da-t3dfv-vteyg-v5agl-tpgrm-63p4y-t5nmm-gi7nl-o72zu-jd3sc-7qe","soulbound":"false","nftQuantities":""}';
 
 xdescribe('config module', () => {
   describe('getArgValue', () => {
-    test('should return string value of string object key e', () => {
+    test('should return string value of string object key "c"', () => {
       const configModule = rewire(`${BUILD_FOLDER}/methods/arg-parser`);
       const getArgValue = configModule.__get__('getArgValue');
 
-      const expected = 'local';
-      const actual = getArgValue(JSON.parse(inputArgvShortNames), ['-e', '--environment']);
+      const expected = 'bayc';
+      const actual = getArgValue(JSON.parse(inputArgvShortNames), ['-c']);
 
       expect(actual).toEqual(expected);
     });
 
-    test('should return string value of string object key environment', () => {
+    test('should return string value of string object key "collectionId"', () => {
       const configModule = rewire(`${BUILD_FOLDER}/methods/arg-parser`);
       const getArgValue = configModule.__get__('getArgValue');
 
-      const expected = 'local';
-      const actual = getArgValue(JSON.parse(inputArgvLongNames), ['-e', '--environment']);
+      const expected = 'bayc';
+      const actual = getArgValue(JSON.parse(inputArgvLongNames), ['--collectionId']);
 
       expect(actual).toEqual(expected);
     });
@@ -42,7 +42,6 @@ xdescribe('config module', () => {
   describe('parseConfigArgs', () => {
     test('should return ConfigArgs with with all args present', () => {
       const expected = {
-        environment: 'local',
         collectionId: 'bayc',
         collectionDisplayName: 'BAYC',
         tokenPrefix: 'bayc-',
@@ -63,7 +62,6 @@ xdescribe('config module', () => {
 
     test('should return ConfigArgs with valid defaults', () => {
       const expected = {
-        environment: 'local',
         collectionId: 'bayc',
         collectionDisplayName: 'BAYC',
         tokenPrefix: 'bayc-',

--- a/src/__tests__/mint.test.ts
+++ b/src/__tests__/mint.test.ts
@@ -5,7 +5,7 @@ import { MintArgs } from '../types/mint';
 const TEN_MINUTE_TIMEOUT = 10 * 60 * 1000;
 
 const inputMintArgs =
-  '{"folderPath":"/Users/jt/test/origyn_nft_reference/projects/bayc-csm/__temp","keyFilePath":"/Users/jt/test/origyn_nft_reference/seed.txt"}';
+  '{"environment":"local","folderPath":"/Users/jt/test/origyn_nft_reference/projects/bayc-csm/__temp","keyFilePath":"/Users/jt/test/origyn_nft_reference/seed.txt"}';
 
 describe('mint module', () => {
   describe('mint', () => {

--- a/src/__tests__/stage.test.ts
+++ b/src/__tests__/stage.test.ts
@@ -5,7 +5,7 @@ import { StageArgs } from '../types/stage';
 const TEN_MINUTE_TIMEOUT = 10 * 60 * 1000;
 
 const inputStageArgs =
-  '{"folderPath":"/Users/jt/test/origyn_nft_reference/projects/bayc-csm/__temp","keyFilePath":"/Users/jt/test/origyn_nft_reference/seed.txt"}';
+  '{"environment":"local","folderPath":"/Users/jt/test/origyn_nft_reference/projects/bayc-csm/__temp","keyFilePath":"/Users/jt/test/origyn_nft_reference/seed.txt"}';
 
 describe('stage module', () => {
   describe('stage', () => {

--- a/src/methods/actor.ts
+++ b/src/methods/actor.ts
@@ -5,11 +5,11 @@ import { idlFactory } from '../idl/origyn_nft_reference.did';
 import { AnyActor } from '../types/actor';
 import { getIdentity } from './identity';
 
-export async function getActor(isProd: boolean, keyFilePath: string, canisterId: string): Promise<AnyActor> {
+export async function getActor(isLocal: boolean, keyFilePath: string, canisterId: string): Promise<AnyActor> {
   const identity = await getIdentity(keyFilePath);
 
-  const agent = getAgent(isProd ? 'https://boundary.ic0.app' : 'http://localhost:8000', identity);
-  if (!isProd) {
+  const agent = getAgent(isLocal ? 'http://localhost:8000' : 'https://boundary.ic0.app', identity);
+  if (isLocal) {
     agent.fetchRootKey();
   }
 

--- a/src/methods/arg-parser.ts
+++ b/src/methods/arg-parser.ts
@@ -6,7 +6,6 @@ export function parseConfigArgs(argv: string[]): ConfigArgs {
   const nftCanisterId = getArgValue(argv, ['-i', '--nftCanisterId']);
 
   const args: ConfigArgs = {
-    environment: getArgValue(argv, ['-e', '--environment']),
     collectionId: getArgValue(argv, ['-c', '--collectionId']),
     collectionDisplayName: getArgValue(argv, ['-d', '--collectionDisplayName']),
     tokenPrefix: getArgValue(argv, ['-t', '--tokenPrefix']),
@@ -17,15 +16,12 @@ export function parseConfigArgs(argv: string[]): ConfigArgs {
     assetMappings: getArgValue(argv, ['-m', '--assetMappings']),
     //optional args
     nftOwnerId: getArgValue(argv, ['-o', '--nftOwnerId'], nftCanisterId),
-    useProxy: getArgValue(argv, ['-u', '--useProxy'], 'false'),
     soulbound: getArgValue(argv, ['-s', '--soulbound'], 'false'),
     nftQuantities: getArgValue(argv, ['-q', '--nftQuantities']),
   };
 
   // validate args
-  if (!args.environment) {
-    throw 'Missing environment argument (-e).';
-  } else if (!args.collectionId) {
+  if (!args.collectionId) {
     throw 'Missing collection id argument (-c) with the id of the collection used in the URL and __apps section.';
   } else if (!args.collectionDisplayName) {
     throw 'Missing collection display name argument (-d).';
@@ -48,12 +44,15 @@ export function parseConfigArgs(argv: string[]): ConfigArgs {
 
 export function parseStageArgs(argv: string[]): StageArgs {
   const args: StageArgs = {
+    environment: getArgValue(argv, ['-e', '--environment']),
     folderPath: getArgValue(argv, ['-f', '--folderPath']),
     keyFilePath: getArgValue(argv, ['-k', '--keyFilePath']),
   };
 
   // validate args
-  if (!args.folderPath) {
+  if (!args.environment) {
+    throw 'Missing environment argument (-e).';
+  } else if (!args.folderPath) {
     throw 'Missing folder path argument (-f) with the path to the folder containing the NFT assets.';
   } else if (!args.keyFilePath) {
     throw 'Missing seed file path argument (-s)';
@@ -64,14 +63,19 @@ export function parseStageArgs(argv: string[]): StageArgs {
 
 export function parseMintArgs(argv: string[]): MintArgs {
   const args: MintArgs = {
+    environment: getArgValue(argv, ['-e', '--environment']),
     folderPath: getArgValue(argv, ['-f', '--folderPath']),
     keyFilePath: getArgValue(argv, ['-k', '--keyFilePath']),
+
+    // optional
     range: getArgValue(argv, ['-r', '--range']),
     batchSize: getArgValue(argv, ['-b', '--batchSize']),
   };
 
   // validate args
-  if (!args.folderPath) {
+  if (!args.environment) {
+    throw 'Missing environment argument (-e).';
+  } else if (!args.folderPath) {
     throw 'Missing folder path argument (-f) with the path to the folder containing the NFT assets.';
   } else if (!args.keyFilePath) {
     throw 'Missing seed file path argument (-s)';

--- a/src/methods/config.ts
+++ b/src/methods/config.ts
@@ -155,36 +155,29 @@ function initConfigSettings(args: ConfigArgs): ConfigSettings {
   return settings;
 }
 
-function getResourceUrl(settings: ConfigSettings, resourceName: string, tokenId: string = ''): string {
-  let rootUrl = '';
-  switch ((settings.args.environment || '').toLowerCase()) {
-    case 'l':
-    case 'local':
-    case 'localhost':
-      if (settings.args.useProxy === 'true') {
-        // url points to icx-proxy (port 3000) to buffer videos
-        rootUrl = `http://localhost:3000/-/${settings.args.nftCanisterId}`;
-      } else {
-        // url points to local canister (port 8000) but does not buffer videos
-        rootUrl = `http://${settings.args.nftCanisterId}.localhost:8000`;
-      }
-      break;
-    case 'p':
-    case 'prod':
-    case 'production':
-      rootUrl = `https://exos.origyn.network/-/${settings.args.collectionId}`;
-      break;
-    default: // dev, stage, etc.
-      rootUrl = `https://exos.origyn.network/-/${settings.args.nftCanisterId}`;
-      break;
-  }
+function getResourceUrl(resourceName: string, tokenId: string = ''): string {
+  // Relative URLs can be tested with the proper root URL:
+
+  // Localhost without proxy, without phonebook:
+  // http://{canister-id}.localhost:8000/
+  // Localhost with proxy, without phonebook:
+  // http://localhost:3000/-/{canister-id}/
+  // Localhost with proxy, with phonebook:
+  // http://localhost:3000/-/{collection-id}/
+
+  // Mainnet without proxy, without phonebook (fully decentralized):
+  // https://rrkah-fqaaa-aaaaa-aaaaq-cai.raw.ic0.app/
+  // Mainnet with proxy, without phonebook:
+  // https://exos.origyn.network/-/{canister-id}/
+  // Mainnet with proxy, with phonebook:
+  // https://exos.origyn.network/-/{collection-id}/
 
   if (tokenId) {
-    // https://rrkah-fqaaa-aaaaa-aaaaq-cai.raw.ic0.app/-/bayc-01/-/com.bayc.ape.0.primary
-    return `${rootUrl}/-/${tokenId}/-/${resourceName}`.toLowerCase();
+    // Example: https://rrkah-fqaaa-aaaaa-aaaaq-cai.raw.ic0.app/-/bayc-01/-/com.bayc.ape.0.primary
+    return `-/${tokenId}/-/${resourceName}`.toLowerCase();
   } else {
-    // https://frfol-iqaaa-aaaaj-acogq-cai.raw.ic0.app/collection/-/ledger
-    return `${rootUrl}/collection/-/${resourceName}`.toLowerCase();
+    // Example: https://frfol-iqaaa-aaaaj-acogq-cai.raw.ic0.app/collection/-/ledger
+    return `collection/-/${resourceName}`.toLowerCase();
   }
 }
 
@@ -212,7 +205,7 @@ function buildFileMap(settings: ConfigSettings): FileInfoMap {
       title = `${libraryId} dApp`;
     }
 
-    const resourceUrl = `${getResourceUrl(settings, libraryId)}`.toLowerCase();
+    const resourceUrl = `${getResourceUrl(libraryId)}`.toLowerCase();
     const relativeFilePath = path.relative(settings.stageFolder, filePath);
 
     fileInfoMap[relativeFilePath.toLowerCase()] = {
@@ -243,7 +236,7 @@ function buildFileMap(settings: ConfigSettings): FileInfoMap {
       for (const filePath of nftFiles) {
         const libraryId = `${settings.args.namespace}.${path.basename(filePath)}`.toLowerCase();
 
-        const resourceUrl = `${getResourceUrl(settings, libraryId, tokenId)}`;
+        const resourceUrl = `${getResourceUrl(libraryId, tokenId)}`;
 
         // find the asset type of this file (primary, preview, experience, hidden)
         let nftAssetType = '';

--- a/src/methods/mint.ts
+++ b/src/methods/mint.ts
@@ -13,6 +13,10 @@ export async function mint(args: MintArgs) {
   log('Started (mint subcommand)');
 
   // *** validate args
+  if (!['local', 'ic'].includes(args.environment)) {
+    const err = `Invalid environment (-e): "${args.environment}". Valid values are "local" (localhost) and "ic" (mainnet).`;
+  }
+
   let mintRange: number[] | null = null;
   if (args.range) {
     const ranges = args.range.split('-');
@@ -44,8 +48,8 @@ export async function mint(args: MintArgs) {
   const json = fs.readFileSync(configFilePath).toString();
   const config = JSON.parse(json) as ConfigFile;
 
-  const isProd = (config.settings.args.environment?.[0] || '').toLowerCase() !== 'l';
-  const actor = await getActor(isProd, args.keyFilePath || 'seed.txt', config.settings.args.nftCanisterId);
+  const isLocal = args.environment === 'local';
+  const actor = await getActor(isLocal, args.keyFilePath || 'seed.txt', config.settings.args.nftCanisterId);
 
   // *** Mint NFTs
   mintRange = mintRange || [0, config.nfts.length - 1];

--- a/src/methods/stage.ts
+++ b/src/methods/stage.ts
@@ -14,7 +14,11 @@ export async function stage(args: StageArgs) {
   log(`\n${constants.LINE_DIVIDER_SUBCOMMAND}\n`);
   log('Started (stage subcommand)');
 
-  // validate args
+  // *** validate args
+  if (!['local', 'ic'].includes(args.environment)) {
+    const err = `Invalid environment (-e): "${args.environment}". Valid values are "local" (localhost) and "ic" (mainnet).`;
+  }
+
   if (!args.folderPath) {
     throw 'Missing folder argument (-f) with the path to the folder containing the NFT assets.';
   }
@@ -29,8 +33,8 @@ export async function stage(args: StageArgs) {
   const json = fs.readFileSync(configFilePath).toString();
   const config = JSON.parse(json) as ConfigFile;
 
-  const isProd = (config.settings.args.environment?.[0] || '').toLowerCase() !== 'l';
-  const actor = await getActor(isProd, args.keyFilePath || 'seed.txt', config.settings.args.nftCanisterId);
+  const isLocal = args.environment === 'local';
+  const actor = await getActor(isLocal, args.keyFilePath || 'seed.txt', config.settings.args.nftCanisterId);
 
   // *** Stage NFTs and Library Assets
   // nfts and collections have the same metadata structure

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,7 +1,6 @@
 import { LibraryFile, Meta } from './metadata';
 
 export type ConfigArgs = {
-  environment: string;
   collectionId: string;
   collectionDisplayName: string;
   tokenPrefix: string;
@@ -18,9 +17,6 @@ export type ConfigArgs = {
 
   // if empty, defaults to NFT canister id
   nftOwnerId: string;
-  // indicates if the resource urls should point at the local icx-proxy (port 3000)
-  // if empty, defaults to 'false'
-  useProxy: string;
   // if empty, defaults to 'false'
   soulbound: string;
   // string with comma delimited list of 'nft_def_number:quantity, ...'

--- a/src/types/mint.ts
+++ b/src/types/mint.ts
@@ -1,6 +1,6 @@
-export type MintArgs = {
-  folderPath: string;
-  keyFilePath: string;
+import { StageArgs } from './stage';
+
+export type MintArgs = StageArgs & {
   range?: string;
   batchSize?: string;
 };

--- a/src/types/stage.ts
+++ b/src/types/stage.ts
@@ -1,4 +1,5 @@
 export type StageArgs = {
+  environment: string;
   folderPath: string;
   keyFilePath: string;
 };


### PR DESCRIPTION
- Updated csm library to generate metadata with relative URLs.
- This removed the need for the environment setting in the config function, so it was moved to the stage and mint functions.
- Updated docs and tests.

Jira ticket: https://origyn.atlassian.net/browse/CMA-25