### PR TITLE
SI-122 Remove Secp256k1 Private Key Code

### DIFF
--- a/src/methods/identity.ts
+++ b/src/methods/identity.ts
@@ -10,24 +10,20 @@ import fs from 'fs';
 import path from 'path';
 import { Identity } from '@dfinity/agent';
 import hdkey from 'hdkey';
-import sha256 from 'sha256';
 import pemfile from 'pem-file';
 import { mnemonicToSeed } from 'bip39';
 import { Secp256k1KeyIdentity, Ed25519KeyIdentity } from '@dfinity/identity';
 import { log } from './logger';
 
+// Loads an Ed25519 private key or a Secp256k1 seed phrase from a file and creates
+// an Identity that can be used in actor references to call canister functions.
 export async function getIdentity(keyFilePath: string): Promise<Identity> {
   const contents = fs.readFileSync(keyFilePath).toString();
   const fileExt = path.extname(keyFilePath).toLowerCase();
 
   if (fileExt === '.pem') {
-    if (contents.indexOf('BEGIN EC PRIVATE KEY') > -1) {
-      const rawBuffer = Uint8Array.from(contents as any).buffer;
-      const privateKey = Uint8Array.from(sha256(rawBuffer as any, { asBytes: true }));
-      const identity = Secp256k1KeyIdentity.fromSecretKey(privateKey);
-      log(`Loaded Secp256k1 identity ${identity.getPrincipal()} from .pem file ${keyFilePath}.`);
-      return identity;
-    } else if (contents.indexOf('BEGIN PRIVATE KEY')) {
+    if (contents.indexOf('BEGIN PRIVATE KEY')) {
+      // Try to load Ed25519 private key
       var buf = pemfile.decode(contents);
       if (buf.length != 85) {
         throw 'expecting byte length 85 but got ' + buf.length;
@@ -40,7 +36,7 @@ export async function getIdentity(keyFilePath: string): Promise<Identity> {
       throw 'Could not recognize the private key type.';
     }
   } else if ((contents || '').split(' ').length === 12) {
-    // seed file
+    // Try to load Secp256k1 seed file
     let seed: Buffer = await mnemonicToSeed(contents);
     const root = hdkey.fromMasterSeed(seed);
     const addrnode = root.derive("m/44'/223'/0'/0/0");
@@ -48,7 +44,7 @@ export async function getIdentity(keyFilePath: string): Promise<Identity> {
     log(`Loaded identity ${identity.getPrincipal()} from seed phrase file ${keyFilePath}.`);
     return identity;
   } else {
-    log(`Invalid seed phrase file ${keyFilePath}`);
-    throw 'Invalid seed phrase';
+    const err = `Could not load identity from ${keyFilePath}`;
+    throw err;
   }
 }

--- a/src/methods/identity.ts
+++ b/src/methods/identity.ts
@@ -21,20 +21,16 @@ export async function getIdentity(keyFilePath: string): Promise<Identity> {
   const contents = fs.readFileSync(keyFilePath).toString();
   const fileExt = path.extname(keyFilePath).toLowerCase();
 
-  if (fileExt === '.pem') {
-    if (contents.indexOf('BEGIN PRIVATE KEY')) {
-      // Try to load Ed25519 private key
-      var buf = pemfile.decode(contents);
-      if (buf.length != 85) {
-        throw 'expecting byte length 85 but got ' + buf.length;
-      }
-      let privateKey = Buffer.concat([buf.slice(16, 48), buf.slice(53, 85)]);
-      const identity = Ed25519KeyIdentity.fromSecretKey(privateKey);
-      log(`Loaded Ed25519 identity ${identity.getPrincipal()} from .pem file ${keyFilePath}.`);
-      return identity;
-    } else {
-      throw 'Could not recognize the private key type.';
+  if (fileExt === '.pem' && contents.indexOf('BEGIN PRIVATE KEY') > -1) {
+    // Try to load Ed25519 private key
+    var buf = pemfile.decode(contents);
+    if (buf.length != 85) {
+      throw 'expecting byte length 85 but got ' + buf.length;
     }
+    let privateKey = Buffer.concat([buf.slice(16, 48), buf.slice(53, 85)]);
+    const identity = Ed25519KeyIdentity.fromSecretKey(privateKey);
+    log(`Loaded Ed25519 identity ${identity.getPrincipal()} from .pem file ${keyFilePath}.`);
+    return identity;
   } else if ((contents || '').split(' ').length === 12) {
     // Try to load Secp256k1 seed file
     let seed: Buffer = await mnemonicToSeed(contents);


### PR DESCRIPTION
- The current code was not able to produce the correct principal ID when loading a pem file with a Secp256k1 private key. 
   (Thanks for catching it Brady.)
- However, it works correctly with the seed phrase.
- Removed the pk code.