### PR TITLE
SI-166 Default Owner to Creator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origyn-sa/csm",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "JavaScript library for configuring, staging and minting Origyn NFTs from a local directory.",
   "keywords": [
     "csm",

--- a/src/methods/arg-parser.ts
+++ b/src/methods/arg-parser.ts
@@ -3,22 +3,22 @@ import { MintArgs } from '../types/mint';
 import { StageArgs } from '../types/stage';
 
 export function parseConfigArgs(argv: string[]): ConfigArgs {
-  const nftCanisterId = getArgValue(argv, ['-i', '--nftCanisterId']);
+  const creatorPrincipal = getArgValue(argv, ['-p', '--creatorPrincipal']);
 
   const args: ConfigArgs = {
     collectionId: getArgValue(argv, ['-c', '--collectionId']),
     collectionDisplayName: getArgValue(argv, ['-d', '--collectionDisplayName']),
     tokenPrefix: getArgValue(argv, ['-t', '--tokenPrefix']),
-    nftCanisterId,
-    creatorPrincipal: getArgValue(argv, ['-p', '--creatorPrincipal']),
+    nftCanisterId: getArgValue(argv, ['-i', '--nftCanisterId']),
+    creatorPrincipal,
     namespace: getArgValue(argv, ['-n', '--namespace']),
     folderPath: getArgValue(argv, ['-f', '--folderPath']),
     assetMappings: getArgValue(argv, ['-m', '--assetMappings']),
     //optional args
-    brokerRoyalty: getArgValue(argv, [ '--brokerRoyalty']),
-    customRoyalty: getArgValue(argv, [ '--customRoyalty']),
-    origynatorRoyalty: getArgValue(argv, [ '--origynatorRoyalty']),
-    nftOwnerId: getArgValue(argv, ['-o', '--nftOwnerId'], nftCanisterId),
+    brokerRoyalty: getArgValue(argv, [ '--brokerRoyalty'], '0.05'),
+    customRoyalty: getArgValue(argv, [ '--customRoyalty'], '0.05'),
+    origynatorRoyalty: getArgValue(argv, [ '--origynatorRoyalty'], '0.05'),
+    nftOwnerId: getArgValue(argv, ['-o', '--nftOwnerId'], creatorPrincipal),
     soulbound: getArgValue(argv, ['-s', '--soulbound'], 'false'),
     nftQuantities: getArgValue(argv, ['-q', '--nftQuantities']),
   };

--- a/src/methods/config.ts
+++ b/src/methods/config.ts
@@ -315,7 +315,7 @@ function configureCollectionMetadata(settings: ConfigSettings): Meta {
     );
   }
 
-  properties.push(createTextAttrib('owner', settings.args.nftOwnerId || settings.args.nftCanisterId, !immutable));
+  properties.push(createTextAttrib('owner', settings.args.nftOwnerId || settings.args.creatorPrincipal, !immutable));
   // attribs.push(
   //     createBoolAttrib('is_soulbound', settings.args.soulbound, !immutable)
   // );
@@ -454,7 +454,7 @@ function configureNftMetadata(settings: ConfigSettings, nftIndex: number): Meta 
     );
   }
 
-  properties.push(createTextAttrib('owner', settings.args.nftOwnerId || settings.args.nftCanisterId, !immutable));
+  properties.push(createTextAttrib('owner', settings.args.nftOwnerId || settings.args.creatorPrincipal, !immutable));
   properties.push(createBoolAttrib('is_soulbound', settings.args.soulbound === 'true', !immutable));
 
   // build classes that point to uploaded resources
@@ -560,7 +560,9 @@ function createSecondaryRoyalties(settings: ConfigSettings): MetadataProperty {
               },
               {
                 name: 'rate',
-                value: { Float: settings.args.brokerRoyalty === '' ? 0.05 : Number(settings.args.brokerRoyalty) },
+                value: { 
+                  Float: settings.args.brokerRoyalty === '' ? 0.05 : Number(settings.args.brokerRoyalty)
+                },
                 immutable: true,
               },
               {
@@ -606,7 +608,9 @@ function createSecondaryRoyalties(settings: ConfigSettings): MetadataProperty {
               },
               {
                 name: 'rate',
-                value: { Float: settings.args.origynatorRoyalty === '' ? 0.05 : Number(settings.args.origynatorRoyalty) },
+                value: {
+                  Float: settings.args.origynatorRoyalty === '' ? 0.05 : Number(settings.args.origynatorRoyalty)
+                },
                 immutable: true,
               },
               {
@@ -629,7 +633,9 @@ function createSecondaryRoyalties(settings: ConfigSettings): MetadataProperty {
               },
               {
                 name: 'rate',
-                value: { Float: settings.args.customRoyalty === '' ? 0.05 : Number(settings.args.customRoyalty) },
+                value: {
+                  Float: settings.args.customRoyalty === '' ? 0.05 : Number(settings.args.customRoyalty)
+                },
                 immutable: true,
               },
               {


### PR DESCRIPTION
- Changed config function to set the owner of the collection and all nfts to the creator's principal id, not the NFT canister id.