### PR TITLE
SI-194 Token IDs as Words

### DIFF
--- a/src/methods/arg-parser.ts
+++ b/src/methods/arg-parser.ts
@@ -10,6 +10,9 @@ export function parseConfigArgs(argv: string[]): ConfigArgs {
     collectionId: getArgValue(argv, ['-c', '--collectionId']),
     collectionDisplayName: getArgValue(argv, ['-d', '--collectionDisplayName']),
     tokenPrefix: getArgValue(argv, ['-t', '--tokenPrefix']),
+    tokenWords: getArgValue(argv, ['-w', '--tokenWords']),
+    minWords: getArgValue(argv, ['--minWords'], "3"),
+    maxWords: getArgValue(argv, ['--maxWords'], "3"),
     nftCanisterId: getArgValue(argv, ['-i', '--nftCanisterId']),
     creatorPrincipal,
     namespace: getArgValue(argv, ['-n', '--namespace']),
@@ -46,8 +49,8 @@ export function parseConfigArgs(argv: string[]): ConfigArgs {
     throw 'Missing collection id argument (-c) with the id of the collection used in the URL and __apps section.';
   } else if (!args.collectionDisplayName) {
     throw 'Missing collection display name argument (-d).';
-  } else if (!args.tokenPrefix) {
-    throw 'Missing token prefix argument (-t).';
+  } else if (!args.tokenPrefix && !args.tokenWords) {
+    throw 'Missing token prefix argument (-t) or token words (-w).';
   } else if (!args.nftCanisterId) {
     throw 'Missing canister id argument (-i).';
   } else if (!args.creatorPrincipal) {
@@ -104,6 +107,7 @@ export function parseMintArgs(argv: string[]): MintArgs {
 
   return args;
 }
+
 export function parseAssetTypeMapPatterns(patterns: string): AssetTypeMap {
   // --assetType "primary:nft*.png, preview:preview*.png"
 

--- a/src/methods/token-ids.ts
+++ b/src/methods/token-ids.ts
@@ -1,0 +1,41 @@
+// credit: https://github.com/firstandthird/combinations/issues/12
+
+// returns a unique and shuffled list of word combinations separated by hyphens
+export function getTokenIds (words: string[], minLength?: number, maxLength?: number, maxCount?: number): string[] {
+  minLength = minLength || 1;
+  maxLength = Math.min(maxLength || words.length, words.length);
+
+  const fn = (n: number, src: string[], got: string[], all: string[][]) => {
+    if (n == 0) {
+      if (got.length > 0) {
+        all[all.length] = got;
+      }
+      return;
+    }
+
+    for (let j = 0; j < src.length; j++) {
+      fn(n - 1, src.slice(j + 1), got.concat([src[j]]), all);
+    }
+    return;
+  };
+
+  let all: string[][] = [];
+
+  for (let i = minLength; i <= maxLength; i++) {
+    fn(i, words, [], all);
+  }
+
+  // shuffle the array 3 times
+  // intended to be run by scripts where performance is of little concern
+  let r = 0;
+  while (r < 5) {
+    all.sort(() => Math.random() - 0.5);
+    r++;
+  }
+
+  if (maxCount && all.length > maxCount) {
+    all = all.splice(0, maxCount);
+  }
+
+  return all.map((c) => c.join("-"));
+};

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -4,6 +4,9 @@ export type ConfigArgs = {
   collectionId: string;
   collectionDisplayName: string;
   tokenPrefix: string;
+  tokenWords: string;
+  minWords: string;
+  maxWords: string;
   nftCanisterId: string;
   creatorPrincipal: string;
   namespace: string;
@@ -47,6 +50,7 @@ export type ConfigSettings = {
   stageFolder: string;
   collectionFolder: string;
   nftsFolder: string;
+  tokenIds: string[];
   nftDefinitionCount: number;
   nftQuantities: number[];
   totalNftCount: number;


### PR DESCRIPTION
- Added new module with getTokenIds function that takes an array words and returns a unique, shuffled list of word combinations using the min/max params to determine the number of words to include in each item.
- Added command line args and parsing/validation to build a list of word-based token ids.
- Scripts can provide either --tokenWords or --tokenPrefix (sequential numbers), but the former has priority.