### PR TITLE
SI-204 Fix not enough storage error

### DIFF
--- a/src/methods/metadata.ts
+++ b/src/methods/metadata.ts
@@ -1,0 +1,69 @@
+import path from 'path';
+import {
+  LibraryFile,
+  Meta,
+  MetadataClass,
+  MetadataProperty,
+  NatValue,
+  TextValue,
+  ThawedArrayValue,
+} from '../types/metadata.js';
+import * as utils from '../utils/index.js';
+import { log } from './logger.js';
+
+export function getLibraries(nftOrColl: Meta) {
+  const libraries = (nftOrColl.meta.metadata.Class.find((c) => c.name === 'library')?.value as ThawedArrayValue)?.Array
+    .thawed as MetadataClass[];
+
+  return libraries;
+}
+
+export function getClassByTextAttribute(classes: MetadataClass[], name: string, value: string) {
+  const libraryMetadata = classes?.find((c) =>
+    c?.Class?.find((c) => c?.name === name && (c?.value as TextValue)?.Text === value),
+  );
+
+  return libraryMetadata;
+}
+
+export function getAttribute(nftOrColl: MetadataClass, name: string): MetadataProperty {
+  return nftOrColl?.Class?.find(a => a?.name === name) as MetadataProperty;
+}
+
+export function getLibraryMetadata(stageFolder: string, nftOrColl: Meta, libraryFile: LibraryFile, actualFileSize: number): MetadataClass {
+  const libraryMetadata = getClassByTextAttribute(getLibraries(nftOrColl), 'library_id', libraryFile.library_id);
+  if (!libraryMetadata) {
+    const err = `Could not find metadata for libary ${libraryFile.library_id}`;
+    throw err;
+  }
+
+  // ensure size is correct
+  let librarySizeAttrib = getAttribute(libraryMetadata, 'size');
+  if (librarySizeAttrib) {
+    const libraryFileSize = (librarySizeAttrib?.value as NatValue)?.Nat || 0;
+    if (Number(libraryFileSize) !== actualFileSize) {
+      log(`Warning: The size of file ${libraryFile.library_file} (${libraryFileSize}) in the metadata does not match the actual file size: ${actualFileSize}.`);
+      log('The file may have been modified manually or by a post-config script since the metadata was generated.');
+      log('Replacing file size in metadata with the actual size.');
+
+      librarySizeAttrib.value = { Nat: actualFileSize };
+    }
+  }
+
+  // ensure content hash is correct
+  let contentHashAttrib = getAttribute(libraryMetadata, 'content_hash');
+  if (contentHashAttrib) {
+    const contentHash = (contentHashAttrib?.value as TextValue)?.Text || '';
+    const filePath = path.resolve(stageFolder, libraryFile.library_file);
+    const actualContentHash = utils.getFileHash(filePath);
+    if (contentHash !== actualContentHash) {
+      log(`Warning: The hash of file ${libraryFile.library_file} (${contentHash}) in the metadata does not match the actual hash: ${actualContentHash}.`);
+      log('The file may have been modified manually or by a post-config script since the metadata was generated.');
+      log('Replacing content hash in metadata with the actual hash.');
+
+      contentHashAttrib.value = { Text: actualContentHash };
+    }
+  }
+
+  return libraryMetadata;
+}


### PR DESCRIPTION
- After the post-config script ran in minting-starter, the files were modified, but the metadata.json file had the size/hash from before the modification. 
- When staging, the origyn_nft canister threw an error that there was not enough storage because the allocation (from metadata) was smaller than the actual file size getting staged.
- This fix ensures that the size and hash are always correct when staging a file by resetting the metadata when there is a discrepancy and passing the metadata in the first chunk uploaded.

Note: The post-deploy script will also get updated in minting-starter to avoid this situation entirely.